### PR TITLE
feat: Add support for RTC IRQ pin configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION = $(shell grep Version: mrhat-rx8130/DEBIAN/control | cut -d' ' -f2)
 # TODO: build module for all kernel versions
 KVER ?= 6.1.21+
 TARGET ?=  $(error TARGET not specified for deploy )
+IRQ_PIN ?= 23
 
 all: build/mrhat-rx8130_$(VERSION)-1_armhf.deb
 	@true
@@ -38,6 +39,8 @@ deploy: all
 	rsync -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -avhz --progress build/mrhat-rx8130_$(VERSION)-1_armhf.deb $(TARGET):/tmp/
 	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $(TARGET) -- sudo dpkg -r mrhat-rx8130
 	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $(TARGET) -- sudo dpkg -i /tmp/mrhat-rx8130_$(VERSION)-1_armhf.deb
+	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $(TARGET) -- sudo sed -ri '/^\s*dtoverlay=mrhat-rx8130/d' /boot/config.txt
+	ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $(TARGET) -- "echo 'dtoverlay=mrhat-rx8130:rtc_irq_pin=$(IRQ_PIN)' | sudo tee -a /boot/config.txt"
 
 quickdeploy: driver
 	scp mrhat-rx8130/lib/modules/$(KVER)/rtc-rx8130.ko $(TARGET):/tmp/

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ appear under `/dev/rtc<X>`,and can be interacted with using the standard Linux R
 ## Usage
 
 Install the debian package from the releases.That will place the dtoverlay under the /boot/overlays directory, 
-and the post installation script also adds `dtoverlay=mrhat-rx8130` to the /boot/config.txt if not present. 
-By default, GPIO5 is used as the RTC interrupt pin, but that can be modified, by manually editing the boot config and specifying it there.
-Example:
+post installation you need to configure the device tree by adding `dtoverlay=mrhat-rx8130` to the /boot/config.txt. 
+By default, GPIO23 is used as the RTC interrupt pin, and main battery is enabled without charging, but that can be modified, by manually editing the boot config and specifying it there.
+Example for using GPIO5 for IRQ, disable main battery, enable external EDLC chargeable capacitor:
 ```bash
 # in /boot/config.txt
-dtoverlay=mrhat-rx8130,rtc_irq_pin=18
+dtoverlay=mrhat-rx8130:rtc_irq_pin=5,ext_battery=false,ext_capacitor=true
 ```
 
 ## License

--- a/mrhat-rx8130.dts
+++ b/mrhat-rx8130.dts
@@ -27,7 +27,7 @@
 				compatible = "epson,rx8130";
 				reg = <0x32>; /* I2C address of the RTC */
 				interrupt-parent = <&gpio>;
-				interrupts = <0x05 IRQ_TYPE_EDGE_FALLING>;
+				interrupts = <0x17 IRQ_TYPE_EDGE_FALLING>;
 				wakeup-source;
 				enable-external-battery;
 				status = "okay";
@@ -39,17 +39,21 @@
 		__overlay__ {
 			/* set up pin for RTC IRQ */
 			rx8130_pins: rx8130_pins {
-				brcm,pins = <0x05>;
+				brcm,pins = <0x17>;
 				brcm,function = <0x0>; /* in */
 				brcm,pull = <0>; /* none */
 			};
 		};
 	};
 	__overrides__ {
+		/* GPIO number of interrupt pin for the RTC interrupt */
 		rtc_irq_pin = <&rx8130rtc>, "interrupts:0",
 		              <&rx8130_pins>, "brcm,pins:0";
+		/* Enable this when RTC is powered by the main battery, charging is not enabled */
 		ext_battery = <&rx8130rtc>, "enable-external-battery?";
+		/* Enable this when RTC is powered by a rechargeable battery, RTC will charge the backup battery */
 		ext_capacitor = <&rx8130rtc>, "enable-external-capacitor?";
+		/* Enable this to support wake from alarm (with rtcwake) */
 		wakeup_source = <&rx8130rtc>, "wakeup-source?";
 		
 	};

--- a/mrhat-rx8130/DEBIAN/control
+++ b/mrhat-rx8130/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: mrhat-rx8130
-Version: 0.2.1
+Version: 0.2.2
 Maintainer: Effective Range Kft.
 Architecture: armhf
 Description: Driver and device Tree overlay for the Epson RX8130CE RTC located on Effective-Range MrHAT v1 family of extension hats

--- a/mrhat-rx8130/DEBIAN/postinst
+++ b/mrhat-rx8130/DEBIAN/postinst
@@ -4,11 +4,6 @@ then
     echo "blacklist rtc_ds1307" > /etc/modprobe.d/blacklist-rtc_ds1307.conf 
 fi
 
-echo "unloading rtc_ds1307 driver if present ..."
-if [[ -n "$(lsmod | grep rtc_ds1307)"  ]];
-then
-    rmmod --force rtc_ds1307 || true
-fi
 
 if [[ -z "$(grep rtc-rx8130 /etc/modules)"  ]];
 then 
@@ -17,15 +12,6 @@ then
     depmod
 fi
 
-echo "Adding in dtoverlay to boot config ..."
-grep -qE "^\s*dtoverlay=mrhat-rx8130" /boot/config.txt  ||  echo "dtoverlay=mrhat-rx8130" >> /boot/config.txt
-
-if [[ -n "$(lsmod | grep rtc_rx8130)"  ]];
-then
-    echo "RTC module can't be unloaded when updated, please reboot ... "
-else
-    modprobe rtc-rx8130 || echo "failed to load driver module ..."
-    dtoverlay mrhat-rx8130  || echo "failed to load device tree overlay ... "
-fi;
+echo "Please add 'dtoverlay=mrhat-rx8130' if needed, then reboot ..."
 
 

--- a/mrhat-rx8130/DEBIAN/postrm
+++ b/mrhat-rx8130/DEBIAN/postrm
@@ -1,7 +1,4 @@
 #!/bin/bash
-echo "Removing mrhat-rx8130 from boot config ..."
-grep -qE "^\s*dtoverlay=mrhat-rx8130" /boot/config.txt  &&  sed -ri '/^\s*dtoverlay=mrhat-rx8130/d' /boot/config.txt
-
 echo "Removing module autoload for rtc-rx8130 ..."
 sed -ri '/^\s*rtc-rx8130/d' /etc/modules
 
@@ -10,4 +7,4 @@ rm -f /etc/modprobe.d/blacklist-rtc_ds1307.conf
 
 depmod
 
-echo "removal of mrhat-rx8130 completed, please reboot ..."
+echo "Removal of mrhat-rx8130 completed, please remove 'dtoverlay=mrhat-rx8130' from /boot/config.txt if not needed anymore then reboot ..."

--- a/mrhat-rx8130/DEBIAN/preinst
+++ b/mrhat-rx8130/DEBIAN/preinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+# removing existing dtb file, as it blocks installation
+rm -f /boot/overlays/mrhat-rx8130.dtbo


### PR DESCRIPTION
- remove dtbo file from overlays pre installation to handle apt update errors

- removed automatic dtoverlay, from now on the user manually has to configure it, if it was present in the boot config, it is not touched facilitating driver updates

- updated default IRQ pin number  to match latest PCB design